### PR TITLE
Various usability tweaks to GitHubRepo connections

### DIFF
--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -475,21 +475,15 @@ export class AdminRoom extends AdminRoomCommandHandler {
     }
 
     public async handleCommand(eventId: string, command: string) {
-        const { error, handled } = await handleCommand(this.userId, command, AdminRoom.botCommands, this);
-        if (!handled) {
+        const result = await handleCommand(this.userId, command, AdminRoom.botCommands, this);
+        if (!result.handled) {
             return this.sendNotice("Command not understood");
         }
-        if (error) {
-            return this.sendNotice("Failed to handle command:" + error);
+        
+        if ("error" in result) {
+            return this.sendNotice(`Failed to handle command: ${result.error}`);
         }
         return null;
-        // return this.botIntent.underlyingClient.sendEvent(this.roomId, "m.reaction", {
-        //     "m.relates_to": {
-        //         rel_type: "m.annotation",
-        //         event_id: event_id,
-        //         key: "✅",
-        //     }
-        // });
     }
 
     public async getBridgeState(): Promise<BridgeRoomState> {

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -1,6 +1,7 @@
 import { MatrixEvent, MatrixMessageContent } from "../MatrixEvent";
 import { IssuesOpenedEvent, IssuesEditedEvent } from "@octokit/webhooks-types";
 import { GetConnectionsResponseItem } from "../provisioning/api";
+import { IRichReplyMetadata } from "matrix-bot-sdk";
 
 export interface IConnection {
     /**
@@ -25,7 +26,7 @@ export interface IConnection {
      * When a room gets a message event.
      * @returns Was the message handled
      */
-    onMessageEvent?: (ev: MatrixEvent<MatrixMessageContent>) => Promise<boolean>;
+    onMessageEvent?: (ev: MatrixEvent<MatrixMessageContent>, replyMetadata?: IRichReplyMetadata) => Promise<boolean>;
 
     onIssueCreated?: (ev: IssuesOpenedEvent) => Promise<void>;
 

--- a/src/FormatUtil.ts
+++ b/src/FormatUtil.ts
@@ -19,8 +19,18 @@ interface IMinimalIssue {
     number: number;
     title: string;
     repository_url: string;
-    pull_request?: any;
 }
+
+interface IMinimalPR {
+    html_url: string;
+    id: number;
+    number: number;
+    title: string;
+    user: {
+        login: string;
+    };
+}
+
 
 export interface ILabel {
     color?: string,
@@ -65,11 +75,24 @@ export class FormatUtil {
                 id: issue.id,
                 number: issue.number,
                 title: issue.title,
-                is_pull_request: !!issue.pull_request,
                 url: issue.html_url,
             },
         };
     }
+
+    public static getPartialBodyForGitHubPR(repo: IMinimalRepository, issue: IMinimalPR) {
+        return {
+            ...FormatUtil.getPartialBodyForRepo(repo),
+            "external_url": issue.html_url,
+            "uk.half-shot.matrix-hookshot.github.pull_request": {
+                id: issue.id,
+                number: issue.number,
+                title: issue.title,
+                url: issue.html_url,
+            },
+        };
+    }
+
 
     public static getPartialBodyForComment(comment: {id: number, html_url: string},
                                            repo?: IMinimalRepository,

--- a/src/Github/Router.ts
+++ b/src/Github/Router.ts
@@ -12,7 +12,7 @@ interface GitHubAccountStatus {
     username?: string;
     organisations?: {
         name: string;
-        avatarUrl: string;
+        avatarUrl?: string;
     }[]
 }
 interface GitHubRepoItem {
@@ -64,10 +64,14 @@ export class GitHubProvisionerRouter {
         try {
             const installs = await octokit.apps.listInstallationsForAuthenticatedUser({page: page, per_page: perPage});
             for (const install of installs.data.installations) {
-                organisations.push({
-                    name: install.account!.login!, // org or user name
-                    avatarUrl: install.account!.avatar_url!,
-                });
+                if (install.account) {
+                    organisations.push({
+                        name: install.account.login || "No name", // org or user name
+                        avatarUrl: install.account.avatar_url,
+                    });
+                } else {
+                    log.debug(`Skipping install ${install.id}, has no attached account`);
+                }
             }
         } catch (ex) {
             log.warn(`Failed to fetch orgs for GitHub user ${req.query.userId}`, ex);


### PR DESCRIPTION
- Issues created with `!gh create` show the issue number inside a reaction.
- Small PRs now show the diff inline, optionally.
- Users can review PRs by relying with a :heavy_check_mark: or a :x: and some review text.