### PR TITLE
Make sample config CI diff visible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: yarn
-      - run: node lib/Config/Defaults.js --config > expected-config.sample.yml 
-      - run: cmp --silent config.sample.yml expected-config.sample.yml
+      - run: yarn --ignore-scripts && yarn build:app
+      - run: node lib/Config/Defaults.js --config | diff config.sample.yml - 
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/changelog.d/97.misc
+++ b/changelog.d/97.misc
@@ -1,0 +1,1 @@
+CI jobs now report the diff between the generated config and the in-tree sample config.


### PR DESCRIPTION
We have CI to check if the sample config has changed, but it doesn't show you the diff.