### PR TITLE
Support categorising bot commands

### DIFF
--- a/changelog.d/143.feature
+++ b/changelog.d/143.feature
@@ -1,0 +1,1 @@
+Bot command help text now features category headers, and disabled commands are no longer visible.

--- a/src/BotCommands.ts
+++ b/src/BotCommands.ts
@@ -7,52 +7,79 @@ import { MatrixMessageContent } from "./MatrixEvent";
 const md = new markdown();
 
 export const botCommandSymbol = Symbol("botCommandMetadata");
-export function botCommand(prefix: string, help: string, requiredArgs: string[] = [], optionalArgs: string[] = [], includeUserId = false) {
+export function botCommand(prefix: string, helpOrOpts: string|BotCommandOptions, requiredArgs: string[] = [], optionalArgs: string[] = [], includeUserId = false) {
+    if (typeof helpOrOpts === "string") {
+        return Reflect.metadata(botCommandSymbol, {
+            prefix,
+            help: helpOrOpts,
+            requiredArgs,
+            optionalArgs,
+            includeUserId,
+        });
+    }
     return Reflect.metadata(botCommandSymbol, {
         prefix,
-        help,
-        requiredArgs,
-        optionalArgs,
-        includeUserId,
+        ...helpOrOpts
     });
 }
+export interface BotCommandOptions {
+    help: string,
+    requiredArgs?: string[],
+    optionalArgs?: string[],
+    includeUserId?: boolean,
+    category?: string,
+}
+
+
 type BotCommandResult = {status?: boolean, reaction?: string}|undefined;
 type BotCommandFunction = (...args: string[]) => Promise<BotCommandResult>;
 
-export type BotCommands = {[prefix: string]: {
-    fn: BotCommandFunction,
-    requiredArgs: string[],
-    optionalArgs: string[],
-    includeUserId: boolean,
-}};
+export type BotCommands = {[prefix: string]: {fn: BotCommandFunction} & BotCommandOptions};
+export type HelpFunction = (cmdPrefix?: string, categories?: string[]) => MatrixMessageContent
 
-export function compileBotCommands(...prototypes: Record<string, BotCommandFunction>[]): {helpMessage: (cmdPrefix?: string) => MatrixMessageContent, botCommands: BotCommands} {
-    let content = "Commands:\n";
+export function compileBotCommands(...prototypes: Record<string, BotCommandFunction>[]): {helpMessage: HelpFunction, botCommands: BotCommands} {
     const botCommands: BotCommands = {};
+    const cmdStrs: {[category: string]: string[]} = {};
     prototypes.forEach(prototype => {
         Object.getOwnPropertyNames(prototype).forEach(propetyKey => {
             const b = Reflect.getMetadata(botCommandSymbol, prototype, propetyKey);
             if (b) {
-                const requiredArgs = b.requiredArgs.join(" ");
-                const optionalArgs = b.optionalArgs.map((arg: string) =>  `[${arg}]`).join(" ");
-                content += ` - \`££PREFIX££${b.prefix}\` ${requiredArgs} ${optionalArgs} - ${b.help}\n`;
-                // We know that this is safe.
+                const category = b.category || "default";
+                const requiredArgs = b.requiredArgs?.join(" ") || "";
+                const optionalArgs = b.optionalArgs?.map((arg: string) =>  `[${arg}]`).join(" ") || "";
+                cmdStrs[category] = cmdStrs[category] || []
+                cmdStrs[category].push(` - \`££PREFIX££${b.prefix}\` ${requiredArgs} ${optionalArgs} - ${b.help}`);
+                // We know that these types are safe.
                 botCommands[b.prefix as string] = {
                     fn: prototype[propetyKey],
+                    help: b.help,
                     requiredArgs: b.requiredArgs,
                     optionalArgs: b.optionalArgs,
                     includeUserId: b.includeUserId,
+                    category: b.category,
                 };
             }
         });
     })
     return {
-        helpMessage: (cmdPrefix?: string) => ({
-            msgtype: "m.notice",
-            body: content,
-            formatted_body: md.render(content).replace(/££PREFIX££/g, cmdPrefix || ""),
-            format: "org.matrix.custom.html"
-        }),
+        helpMessage: (cmdPrefix?: string, onlyCategories?: string[]) => {
+            let content = "";
+            for (const [categoryName, commands] of Object.entries(cmdStrs)) {
+                if (categoryName !== "default" && onlyCategories && !onlyCategories.includes(categoryName)) {
+                    continue;
+                }
+                if (categoryName !== "default") {
+                    content += `### ${categoryName[0].toUpperCase()}${categoryName.substring(1).toLowerCase()}\n`;
+                }
+                content += commands.join('\n') + "\n";
+            }
+            return {
+                msgtype: "m.notice",
+                body: content.replace(/££PREFIX££/g, cmdPrefix || ""),
+                formatted_body: md.render(content).replace(/££PREFIX££/g, cmdPrefix || ""),
+                format: "org.matrix.custom.html"
+            }
+        },
         botCommands,
     }
 }
@@ -71,7 +98,7 @@ export async function handleCommand(userId: string, command: string, botCommands
         // We have a match!
         const command = botCommands[prefix];
         if (command) {
-            if (command.requiredArgs.length > parts.length - i) {
+            if (command.requiredArgs && command.requiredArgs.length > parts.length - i) {
                 return {handled: true, error: "Missing args"};
             }
             const args = parts.slice(i);

--- a/src/Github/AdminCommands.ts
+++ b/src/Github/AdminCommands.ts
@@ -20,7 +20,7 @@ export function generateGitHubOAuthUrl(clientId: string, redirectUri: string, st
 }
 
 export class GitHubBotCommands extends AdminRoomCommandHandler {
-    @botCommand("github login", "Login to GitHub")
+    @botCommand("github login", {help: "Login to GitHub", category: "github"})
     public async loginCommand() {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support");
@@ -32,13 +32,13 @@ export class GitHubBotCommands extends AdminRoomCommandHandler {
         return this.sendNotice(`To login, open ${generateGitHubOAuthUrl(this.config.github.oauth.client_id, this.config.github.oauth.redirect_uri, state)} to link your account to the bridge`);
     }
 
-    @botCommand("github startoauth", "Start the OAuth process with GitHub")
+    @botCommand("github startoauth", {help: "Start the OAuth process with GitHub", category: "github"})
     public async beginOAuth() {
         // Legacy command
         return this.loginCommand();
     }
 
-    @botCommand("github setpersonaltoken", "Set your personal access token for GitHub", ['accessToken'])
+    @botCommand("github setpersonaltoken", {help: "Set your personal access token for GitHub", requiredArgs: ['accessToken'], category: "github"})
     public async setGHPersonalAccessToken(accessToken: string) {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support");
@@ -56,7 +56,7 @@ export class GitHubBotCommands extends AdminRoomCommandHandler {
         await this.tokenStore.storeUserToken("github", this.userId, JSON.stringify({access_token: accessToken, token_type: 'pat'} as GitHubOAuthToken));
     }
 
-    @botCommand("github hastoken", "Check if you have a token stored for GitHub")
+    @botCommand("github hastoken", {help: "Check if you have a token stored for GitHub", category: "github"})
     public async hasPersonalToken() {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support");

--- a/src/Jira/AdminCommands.ts
+++ b/src/Jira/AdminCommands.ts
@@ -33,7 +33,7 @@ export function generateJiraURL(clientId: string, redirectUri: string, state: st
 }
 
 export class JiraBotCommands extends AdminRoomCommandHandler {
-    @botCommand("jira login", "Login to JIRA")
+    @botCommand("jira login", {help: "Login to JIRA", category: "jira"})
     public async loginCommand() {
         if (!this.config.jira?.oauth) {
             this.sendNotice(`Bot is not configured with JIRA OAuth support`);
@@ -44,7 +44,7 @@ export class JiraBotCommands extends AdminRoomCommandHandler {
         await this.sendNotice(`To login, open ${generateJiraURL(cfg.client_id, cfg.redirect_uri, state)} to link your account to the bridge`);
     }
 
-    @botCommand("jira whoami", "Determine JIRA identity")
+    @botCommand("jira whoami", {help: "Determine JIRA identity", category: "jira"})
     public async whoami() {
         if (!this.config.jira) {
             await this.sendNotice(`Bot is not configured with JIRA OAuth support`);

--- a/tests/AdminRoomTest.ts
+++ b/tests/AdminRoomTest.ts
@@ -14,7 +14,7 @@ function createAdminRoom(data: any = {admin_user: "@admin:bar"}): [AdminRoom, In
         data.admin_user = "@admin:bar";
     }
     const tokenStore = new UserTokenStore("notapath", intent, DefaultConfig);
-    return [new AdminRoom(ROOM_ID, data, NotifFilter.getDefaultContent(), intent, tokenStore, {} as any, ), intent];
+    return [new AdminRoom(ROOM_ID, data, NotifFilter.getDefaultContent(), intent, tokenStore, DefaultConfig), intent];
 }
 
 describe("AdminRoom", () => {
@@ -22,10 +22,9 @@ describe("AdminRoom", () => {
         const [adminRoom, intent] = createAdminRoom();
         await adminRoom.handleCommand("$foo:bar", "help");
         expect(intent.sentEvents).to.have.lengthOf(1);
-
         expect(intent.sentEvents[0]).to.deep.equal({
             roomId: ROOM_ID,
-            content: AdminRoom.helpMessage(),
+            content: AdminRoom.helpMessage(undefined, ["github", "gitlab", "jira"]),
         });
     });
 })


### PR DESCRIPTION
Fixes #138

Bot commands are now categorized according to service, and the help text is now generated based on the configuration. Commands should already be checking for whether a service is active before executing, so this should solve the case where commands are given in help but are not enabled.