### PR TITLE
Mention the last comment on a recently closed/reopened issue.

### DIFF
--- a/changelog.d/144.feature
+++ b/changelog.d/144.feature
@@ -1,0 +1,1 @@
+Automatically append the last comment on a closed GitHub issue notification, if the comment was made when the issue was closed.


### PR DESCRIPTION
Fixes #139 

This is useful where a issue has been closed / reopened and some explanatory text has been added. To avoid spam, this only looks for messages sent in the last 2 minutes.