### PR TITLE
Send a notice to a room when a GitHub issue has been labeled matching a includesLabel

### DIFF
--- a/changelog.d/176.feature
+++ b/changelog.d/176.feature
@@ -1,0 +1,1 @@
+GitHub repo connections will notify when an issue has been labeled if `includingLabels` is configured.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -42,6 +42,7 @@ This connection supports sending messages when the following actions happen on t
   - issue.created
   - issue.changed
   - issue.edited
+  - issue.labeled
 - pull_request
   - pull_request.closed
   - pull_request.merged

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -267,6 +267,17 @@ export class Bridge {
             (c, data) => c.onIssueEdited(data),
         );
 
+        this.bindHandlerToQueue<GitHubWebhookTypes.IssuesUnlabeledEvent, GitHubRepoConnection>(
+            "github.issues.unlabeled",
+            (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
+            (c, data) => c.onIssueUnlabeled(data),
+        );
+        this.bindHandlerToQueue<GitHubWebhookTypes.IssuesLabeledEvent, GitHubRepoConnection>(
+            "github.issues.labeled",
+            (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
+            (c, data) => c.onIssueLabeled(data),
+        );
+
         this.bindHandlerToQueue<GitHubWebhookTypes.PullRequestOpenedEvent, GitHubRepoConnection>(
             "github.pull_request.opened",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
@@ -583,7 +594,7 @@ export class Bridge {
         this.ready = true;
     }
 
-    private async bindHandlerToQueue<EventType, ConnType extends IConnection>(event: string, connectionFetcher: (data: EventType) => ConnType[], handler: (c: ConnType, data: EventType) => Promise<unknown>) {
+    private async bindHandlerToQueue<EventType, ConnType extends IConnection>(event: string, connectionFetcher: (data: EventType) => ConnType[], handler: (c: ConnType, data: EventType) => Promise<unknown>|unknown) {
         this.queue.on<EventType>(event, (msg) => {
             const connections = connectionFetcher.bind(this)(msg.data);
             log.debug(`${event} for ${connections.map(c => c.toString()).join(', ') || '[empty]'}`);


### PR DESCRIPTION
So that rooms can subscribe to issues *after* an issue has been labeled.