### PR TITLE
Do not explicitly pass --target to rustup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /src
 WORKDIR /src
 
 # We need rustup so we have a sensible rust version, the version packed with bullsye is too old
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --target x86_64-unknown-linux-gnu
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459

--- a/changelog.d/184.misc
+++ b/changelog.d/184.misc
@@ -1,0 +1,1 @@
+Do not hardcode `--target x86_64-unknown-linux-gnu` when installing Rust (rely on platform auto-detection instead)


### PR DESCRIPTION
It doesn't seem to be necessary to install Rust.
Passing `--target` prevents the Dockerfile from being built on different architectures.
Not passing it makes it auto-detect what to install.

Actually, I've managed to build this Dockerfile on ARM64 even with the hardcoded `--target`. It's misleading though, so removing it is better.

Discussed here: https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/1505