### PR TITLE
Don't set global displayname for bot in generic hooks

### DIFF
--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -137,6 +137,10 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             return;
         }
         const sender = this.getUserId();
+        if (sender === this.as.botUserId) {
+            // Don't set the global displayname for the bot.
+            return;   
+        }
         const intent = this.as.getIntentForUserId(sender);
         const expectedDisplayname = `${this.state.name} (Webhook)`;
 


### PR DESCRIPTION
Fixes #214 